### PR TITLE
Added BaseScript delay to Rpctrigger::fire()

### DIFF
--- a/Server/Rpc/RpcTrigger.cs
+++ b/Server/Rpc/RpcTrigger.cs
@@ -17,7 +17,9 @@ namespace NFive.Server.Rpc
 
 		public async void Fire(OutboundMessage message)
 		{
+			// Marshall back to the main thread in order to use a native call.
 			await BaseScript.Delay(0);
+
 			this.logger.Debug($"Fire: \"{message.Event}\" with {message.Payloads.Count} payload(s): {string.Join(", ", message.Payloads)}");
 
 			if (message.Target != null)

--- a/Server/Rpc/RpcTrigger.cs
+++ b/Server/Rpc/RpcTrigger.cs
@@ -15,8 +15,9 @@ namespace NFive.Server.Rpc
 			this.serializer = serializer;
 		}
 
-		public void Fire(OutboundMessage message)
+		public async void Fire(OutboundMessage message)
 		{
+			await BaseScript.Delay(0);
 			this.logger.Debug($"Fire: \"{message.Event}\" with {message.Payloads.Count} payload(s): {string.Join(", ", message.Payloads)}");
 
 			if (message.Target != null)


### PR DESCRIPTION
Fixes NFive issue with invalid event invocation:
InvokeNative: execution failed: No current resource manager.