### PR TITLE
Add more Fivem identifier types (XboxLive and Microsoft Acccount)

### DIFF
--- a/Server/Rpc/Client.cs
+++ b/Server/Rpc/Client.cs
@@ -20,6 +20,10 @@ namespace NFive.Server.Rpc
 
 		public ulong? DiscordId { get; }
 
+		private ulong? liveId { get; }
+
+		private ulong? xboxLiveId { get; }
+
 		public int Ping
 		{
 			get
@@ -42,6 +46,8 @@ namespace NFive.Server.Rpc
 			this.License = ids["license"];
 			this.SteamId = ids.ContainsKey("steam") && !string.IsNullOrEmpty(ids["steam"]) ? long.Parse(ids["steam"], NumberStyles.HexNumber) : default(long?);
 			this.DiscordId = ids.ContainsKey("discord") && !string.IsNullOrEmpty(ids["discord"]) ? ulong.Parse(ids["discord"]) : default(ulong?);
+			this.liveId = ids.ContainsKey("live") && !string.IsNullOrEmpty(ids["live"]) ? ulong.Parse(ids["live"]) : default(ulong?);
+			this.xboxLiveId= ids.ContainsKey("xbl") && !string.IsNullOrEmpty(ids["xbl"]) ? ulong.Parse(ids["xbl"]) : default(ulong?);
 		}
 
 		protected Dictionary<string, string> GetIdentifiers()


### PR DESCRIPTION
Fivem has added more 2 identifier types that are related to Windows ! 