### PR TITLE
Features/NUI callback protocol

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
 				async send(event, data = null) {
 					console.log('[NUI] send: ' + this.name + ' - ' + event, JSON.stringify(data));
 
-					return await fetch('http://nfive/' + this.name + '/' + event, {
+					return await fetch('https://nfive/' + this.name + '/' + event, {
 						method: 'post',
 						headers: {
 							'Content-type': 'application/json; charset=UTF-8'


### PR DESCRIPTION
Callbacks are breaking of Cerulean as https became mandatory with that fx_version.

I'm new to the NFive framework and wondering if rather than hard coding this can we pull the fx_version at runtime from an fxmanifest and determine whether to use http or https when displaying the NUIs?

